### PR TITLE
Removes the tabs 

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -37,12 +37,6 @@
     <script src="js/services.js"></script>
   </head>
   <body ng-app="quizmaster">
-    <!--
-      The nav bar that will be updated as we navigate between views.
-    -->
-    <ion-nav-bar class="bar-stable">
-      Quizmaster
-    </ion-nav-bar>
 
     <ion-nav-view></ion-nav-view>
 

--- a/www/index.html
+++ b/www/index.html
@@ -41,14 +41,10 @@
       The nav bar that will be updated as we navigate between views.
     -->
     <ion-nav-bar class="bar-stable">
-      <ion-nav-back-button>
-      </ion-nav-back-button>
+      Quizmaster
     </ion-nav-bar>
-    <!--
-      The views will be rendered in the <ion-nav-view> directive below
-      Templates are in the /templates folder (but you could also
-      have templates inline in this html file if you'd like).
-    -->
+
     <ion-nav-view></ion-nav-view>
+
   </body>
 </html>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -28,7 +28,7 @@ angular.module('quizmaster', ['ionic', 'quizmaster.controllers', 'quizmaster.ser
     ActionCableConfig.autoStart = true;
   })
 
-  .config(function ($stateProvider, $urlRouterProvider) {
+  .config(function ($urlRouterProvider, $stateProvider) {
 
     // Ionic uses AngularUI Router which uses the concept of states
     // Learn more here: https://github.com/angular-ui/ui-router
@@ -36,26 +36,13 @@ angular.module('quizmaster', ['ionic', 'quizmaster.controllers', 'quizmaster.ser
     // Each state's controller can be found in controllers.js
     $stateProvider
 
-    // setup an abstract state for the tabs directive
-      .state('tab', {
-        url: '/tab',
-        abstract: true,
-        templateUrl: 'templates/tabs.html'
-      })
-
-      // Each tab has its own nav history stack:
-
-      .state('tab.dash', {
-        url: '/dash',
-        views: {
-          'tab-dash': {
-            templateUrl: 'templates/tab-dash.html',
-            controller: 'QuizController'
-          }
-        }
+      .state('tabs', {
+        url: '/tabs',
+        templateUrl: 'templates/tabs.html',
+        controller:"QuizController"
       });
 
     // if none of the above states are matched, use this as the fallback
-    $urlRouterProvider.otherwise('/tab/dash');
+    $urlRouterProvider.otherwise('/tabs');
 
   });

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -28,7 +28,7 @@ angular.module('quizmaster', ['ionic', 'quizmaster.controllers', 'quizmaster.ser
     ActionCableConfig.autoStart = true;
   })
 
-  .config(function ($urlRouterProvider, $stateProvider) {
+  .config(function ($stateProvider, $urlRouterProvider) {
 
     // Ionic uses AngularUI Router which uses the concept of states
     // Learn more here: https://github.com/angular-ui/ui-router

--- a/www/templates/tabs.html
+++ b/www/templates/tabs.html
@@ -3,12 +3,12 @@ Create tabs with an icon and label, using the tabs-positive style.
 Each tab's child <ion-nav-view> directive will have its own
 navigation history that also transitions its views in and out.
 -->
-<ion-tabs class="tabs-icon-top tabs-color-active-positive">
-
-  <!-- Dashboard Tab -->
-  <ion-tab title="Status" icon-off="ion-ios-pulse" icon-on="ion-ios-pulse-strong" href="#/tab/dash">
-    <ion-nav-view name="tab-dash"></ion-nav-view>
-  </ion-tab>
-
-
-</ion-tabs>
+<ion-view view-title="Quizmaster">
+  <ion-content>
+    <h2>Quizmaster</h2>
+    <p>
+      This is the home page for our app. It should contain the box for entering a code.
+    </p>
+    <a ng-click="goToQuiz();">Click this link to view the quiz!</a>
+  </ion-content>
+</ion-view>


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/133160063
(I haven't tested if all function remains, but the the modal still pops up, so that works. )

Changes proposed in this pull request:
- Removes the tab at the bottom

What I have learned working on this feature: 
- You need to still use the tab-view for content 

Screenshots:
<img width="746" alt="skarmavbild 2016-10-26 kl 10 20 50" src="https://cloud.githubusercontent.com/assets/7266909/19718507/e89e29fc-9b65-11e6-90d6-46cdea43ca25.png">

Ready for review!
