### PR TITLE
Mobile users can leave quiz and enter a new one

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -2,7 +2,8 @@
 @import url('https://fonts.googleapis.com/css?family=Creepster');
 @import url('https://fonts.googleapis.com/css?family=Open+Sans');
 body {
-  font-size: 16px;
+  font-size: 200%;
+  line-height: normal;
   font-family: 'Open Sans', sans-serif;
 }
 ion-view, ion-modal-view {
@@ -34,10 +35,11 @@ img {
 
 .box h1 {
   font-family: 'Creepster', sans-serif;
+  font-size: 150%;
 }
 .question_container, .question_headline {
   font-family: 'Creepster', sans-serif;
-  font-size:24px;
+  /*font-size:24px;*/
 }
 .answer_submitted {
   display: none;
@@ -49,7 +51,7 @@ img {
   display: inline-block;
   padding: 6px 12px;
   margin-bottom: 0;
-  font-size: 14px;
+  font-size: 100%;
   font-weight: normal;
   line-height: 1.428571429;
   text-align: center;
@@ -69,7 +71,7 @@ img {
   max-height: 50px;
   padding-right:5px;
   padding-left:5px;
-  font-size: 130%;
+  /*font-size: 130%;*/
 }
 .btn-primary {
   color: #FFFFFF;
@@ -97,10 +99,10 @@ img {
 input[type="text"].form-control {
   display: block;
   width: 100%;
-  height: 34px;
+  height: inherit;
   padding: 6px 12px;
-  font-size: 14px;
-  line-height: 1.42857143;
+  font-size: 100%;
+  line-height: inherit;
   color: #555;
   background-color: #fff;
   background-image: none;
@@ -109,7 +111,7 @@ input[type="text"].form-control {
 }
 #send_question { display: inline-block; float:right;}
 .question p {
-  font-size: 20px;
+  /*font-size: 20px;*/
   float:left;
   min-height:50px;
   line-height: 50px;
@@ -163,7 +165,7 @@ input[type="text"].form-control {
   padding: 1%;
 }
 .cancel-icon {
-  font-size: 400%;
+  font-size: 200%;
   color: red;
   opacity: .2;
   position: absolute;

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -16,6 +16,9 @@ ion-view, ion-modal-view {
   background: linear-gradient(to bottom, #ffc501 0%, #fe9600 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffc501', endColorstr='#fe9600', GradientType=0 );
 }
+.scroll{
+  transform: inherit !important;
+}
 img {
   display: block;
   margin: 20px auto;
@@ -158,4 +161,13 @@ input[type="text"].form-control {
   display: block;
   float: right;
   padding: 1%;
+}
+.cancel-icon {
+  font-size: 400%;
+  color: red;
+  opacity: .2;
+  position: absolute;
+  bottom: .2em;
+  right: .3em;
+  z-index: 1;
 }

--- a/www/index.html
+++ b/www/index.html
@@ -32,7 +32,6 @@
     <script src="lib/angular-actioncable/dist/angular-actioncable.min.js"></script>
     <script src="js/app.js"></script>
     <script src="js/controllers.js"></script>
-    <!--<script src="js/services.js"></script>-->
   </head>
   <body ng-app="quizmaster">
 

--- a/www/index.html
+++ b/www/index.html
@@ -32,7 +32,7 @@
     <script src="lib/angular-actioncable/dist/angular-actioncable.min.js"></script>
     <script src="js/app.js"></script>
     <script src="js/controllers.js"></script>
-    <script src="js/services.js"></script>
+    <!--<script src="js/services.js"></script>-->
   </head>
   <body ng-app="quizmaster">
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -5,7 +5,7 @@
 // the 2nd parameter is an array of 'requires'
 // 'starter.services' is found in services.js
 // 'starter.controllers' is found in controllers.js
-angular.module('quizmaster', ['ionic', 'quizmaster.controllers', 'quizmaster.services'])
+angular.module('quizmaster', ['ionic', 'quizmaster.controllers'])
 
   .run(function ($ionicPlatform) {
     $ionicPlatform.ready(function () {

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -15,7 +15,8 @@ angular.module('quizmaster.controllers', ['ngActionCable'])
 
     $scope.findQuiz = function () {
       $ionicLoading.show({
-          template: 'Loading quiz...'
+          template: 'Loading quiz...',
+          duration: 3000
         }
       );
       code = angular.element(document.querySelector('#codeEntry'))[0].value;

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -103,6 +103,11 @@ angular.module('quizmaster.controllers', ['ngActionCable'])
 
     $scope.openModal = function () {
       $scope.modal.show();
+    };
+
+    $scope.closeModal = function () {
+      consumer.unsubscribe();
+      $scope.modal.hide();
     }
 
   })

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -1,50 +1,5 @@
 angular.module('quizmaster.services', [])
 
-.factory('Chats', function() {
-  // Might use a resource here that returns a JSON array
+.factory('Sample', function() {
 
-  // Some fake testing data
-  var chats = [{
-    id: 0,
-    name: 'Ben Sparrow',
-    lastText: 'You on your way?',
-    face: 'img/ben.png'
-  }, {
-    id: 1,
-    name: 'Max Lynx',
-    lastText: 'Hey, it\'s me',
-    face: 'img/max.png'
-  }, {
-    id: 2,
-    name: 'Adam Bradleyson',
-    lastText: 'I should buy a boat',
-    face: 'img/adam.jpg'
-  }, {
-    id: 3,
-    name: 'Perry Governor',
-    lastText: 'Look at my mukluks!',
-    face: 'img/perry.png'
-  }, {
-    id: 4,
-    name: 'Mike Harrington',
-    lastText: 'This is wicked good ice cream.',
-    face: 'img/mike.png'
-  }];
-
-  return {
-    all: function() {
-      return chats;
-    },
-    remove: function(chat) {
-      chats.splice(chats.indexOf(chat), 1);
-    },
-    get: function(chatId) {
-      for (var i = 0; i < chats.length; i++) {
-        if (chats[i].id === parseInt(chatId)) {
-          return chats[i];
-        }
-      }
-      return null;
-    }
-  };
 });

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -1,5 +1,0 @@
-angular.module('quizmaster.services', [])
-
-.factory('Sample', function() {
-
-});

--- a/www/templates/quiz-page.html
+++ b/www/templates/quiz-page.html
@@ -3,11 +3,11 @@
     <div class='box'>
       <h1>Welcome to Quiz: {{quiz.name}}</h1>
       <div id='register_team' ng-hide="registeredTeam">
-        Enter your teamname and press the button!
+        Enter your team name.
         <div class="form-control code">
-          <input type="text" placeholder="Enter a Team Name" class="form-control" id='teamName'>
+          <input type="text" placeholder="Team Name" class="form-control" id='teamName'>
         </div>
-        <button ng-click="registerTeam();" class="btn btn-primary btn-lg btn-block">Register team and play</button>
+        <button ng-click="registerTeam();" class="btn btn-primary btn-lg btn-block">Register and play</button>
       </div>
       <div id='message'></div>
     </div>

--- a/www/templates/quiz-page.html
+++ b/www/templates/quiz-page.html
@@ -12,5 +12,8 @@
       <div id='message'></div>
     </div>
     <img src='../img/logo.png'/>
+    <div class="close-button" ng-click="closeModal()">
+      <i class='icon cancel-icon ion-android-cancel'></i>
+    </div>
   </ion-content>
 </ion-modal-view>

--- a/www/templates/tab-dash.html
+++ b/www/templates/tab-dash.html
@@ -1,9 +1,0 @@
-<ion-view view-title="Dashboard">
-  <ion-content class="padding">
-    <h2>Quizmaster</h2>
-    <p>
-    This is the home page for our app. It should contain the box for entering a code.
-    </p>
-    <a ng-click="goToQuiz();">Click this link to view the quiz!</a>
-  </ion-content>
-</ion-view>

--- a/www/templates/tabs.html
+++ b/www/templates/tabs.html
@@ -10,7 +10,7 @@ navigation history that also transitions its views in and out.
       <div class="form-control code">
         <input type="text" placeholder="Enter your code" class="form-control" id='codeEntry'>
       </div>
-      <button ng-click="findQuiz();" class="btn btn-primary btn-lg btn-block">Click this link to view the quiz!</button>
+      <button ng-click="findQuiz();" class="btn btn-primary btn-lg btn-block">Go to the Quiz!</button>
       <div id='badCode'>
         That's an invalid code. Talk to your Quizmaster.
       </div>

--- a/www/templates/tabs.html
+++ b/www/templates/tabs.html
@@ -6,7 +6,7 @@ navigation history that also transitions its views in and out.
 <ion-view view-title='Quizmaster'>
   <ion-content>
     <div class='box'>
-      <h1>Play the Game</h1>
+      <h1>Quizmaster</h1>
       <div class="form-control code">
         <input type="text" placeholder="Enter your code" class="form-control" id='codeEntry'>
       </div>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/133169373

Changes proposed in this pull request:
- Add `close` button to exit the current quiz and unsubscribe from the channel
- Remove unnecessary `services` bits (but leave placeholder there in case we need to expand functionality in the future)

What I have learned working on this feature:
- It's `$scope.modal.hide();`, not `$scope.modal.close();`

Screenshots:
![screen shot 2016-10-28 at 10 26 07 am](https://cloud.githubusercontent.com/assets/20141428/19799812/f722d524-9cf8-11e6-8136-729463199bf1.png)

Ready for review!
